### PR TITLE
fix: add missing hardfork timestamps to mainnet and hoodi genesis

### DIFF
--- a/hoodi/geth-data/genesis.json
+++ b/hoodi/geth-data/genesis.json
@@ -20,6 +20,7 @@
     "morph203Time": 0,
     "viridianTime": 1761544800,
     "emeraldTime": 1766988000,
+    "jadeTime": 1774418400,
     "morph": {
       "useZktrie": true,
       "maxTxPayloadBytesPerBlock": 122880,

--- a/mainnet/geth-data/genesis.json
+++ b/mainnet/geth-data/genesis.json
@@ -19,6 +19,7 @@
     "morph203Time": 1747029600,
     "viridianTime": 1762149600,
     "emeraldTime": 1767765600,
+    "jadeTime": 1775628000,
     "terminalTotalDifficulty": 0,
     "morph": {
       "useZktrie": true,


### PR DESCRIPTION
## Summary

- Add `morph203Time`, `viridianTime`, `emeraldTime` to `mainnet/geth-data/genesis.json`
- Add `viridianTime`, `emeraldTime` to `hoodi/geth-data/genesis.json`

## Background

go-ethereum determines hardfork activation from hardcoded configs (`MorphMainnetChainConfig` / `MorphHoodiChainConfig` in `params/config.go`). When geth starts with `--morph` or `--morph-hoodi`, it always overwrites the stored chain config with these hardcoded values — so geth sync works regardless of what's in genesis.json.

However, other clients (e.g. morph-reth) rely purely on genesis.json to determine hardfork activation. Without these fields, timestamp-based hardforks (Morph203, Viridian, Emerald) are never activated.

## Values (from go-ethereum `params/config.go`)

**Mainnet (chain ID 2818):**
| Field | Value | Date |
|-------|-------|------|
| `morph203Time` | 1747029600 | 2025-05-12 |
| `viridianTime` | 1762149600 | 2025-10-04 |
| `emeraldTime` | 1767765600 | 2026-01-07 |

**Hoodi (chain ID 2910):**
| Field | Value | Date |
|-------|-------|------|
| `viridianTime` | 1761544800 | 2025-10-27 |
| `emeraldTime` | 1766988000 | 2025-12-29 |

(`morph203Time: 0` was already present in hoodi)

## Test Plan

- [x] `geth init mainnet/geth-data/genesis.json` — exit 0, genesis hash unchanged (`649c9b..cfa7a9`)
- [x] `geth init hoodi/geth-data/genesis.json` — exit 0, genesis hash unchanged (`2cbcff..bfc35c`)